### PR TITLE
fix: Add refresh button in Reference app to pull the updated experience in reference app

### DIFF
--- a/genstudio-create-validation/src/genstudiopem/web-src/src/components/RightPanel.tsx
+++ b/genstudio-create-validation/src/genstudiopem/web-src/src/components/RightPanel.tsx
@@ -38,10 +38,9 @@ export default function RightPanel(): JSX.Element {
     try {
       const remoteExperiences = await ExperienceService.getExperiences(guestConnection);
       // Add a minimum loading time of 0.5 seconds
-      setTimeout(() => {
-        setExperiences(remoteExperiences);
-        setIsLoading(false);
-      }, 500);
+      await new Promise(resolve => setTimeout(resolve, 500));
+      setExperiences(remoteExperiences);
+      setIsLoading(false);
     } catch (error) {
       console.error("Error fetching experiences:", error);
       setIsLoading(false);

--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/RightPanel.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/RightPanel.tsx
@@ -60,9 +60,9 @@ export default function RightPanel(): JSX.Element {
   const runClaimsCheck = async (experience: Experience, selectedExperienceIndex: number, selectedClaimLibrary: any): Promise<void> => {
     setIsLoading(true);
     try {
-      // Add artificial delay if needed for UX
-      await new Promise(resolve => setTimeout(resolve, 1500));
       const result = validateClaims(experience, selectedExperienceIndex, selectedClaimLibrary);
+        // Add a minimum loading time of 0.5 seconds
+        await new Promise(resolve => setTimeout(resolve, 500));
         // Update state with results
         setClaimsResult(result);
     } catch (error) {

--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/RightPanel.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/RightPanel.tsx
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import React, { Key, useEffect, useState } from 'react';
 import { attach } from "@adobe/uix-guest";
 import { extensionId, TEST_CLAIMS } from "../Constants";
-import { View, Provider, defaultTheme, Button, ComboBox, Item, Flex, Divider, Picker, Text } from '@adobe/react-spectrum';
+import { View, Provider, defaultTheme, Button, ComboBox, Item, Flex, Divider, Picker, Text, Heading } from '@adobe/react-spectrum';
 import { Experience, ExperienceService } from '@adobe/genstudio-uix-sdk';
 import { validateClaims } from '../utils/claimsValidation';
 import ClaimsChecker from './ClaimsChecker';
@@ -34,14 +34,6 @@ export default function RightPanel(): JSX.Element {
       setGuestConnection(connection as any);
     })();
   }, []);
-
-  useEffect(() => {
-    (async () => {
-      if (guestConnection) {
-        await getExperience();
-      }
-    })();
-  }, [guestConnection]);
 
   const handleClaimsLibrarySelection = (library: Key | null) => {
     if (library === null) return;
@@ -106,15 +98,29 @@ export default function RightPanel(): JSX.Element {
           {experiences && experiences.length > 0 ? (
             <Flex direction="column" gap="size-200">
               <View paddingX="size-200" paddingY="size-100">
-              <Picker
-                label="Select a claim library"
-                width="100%"
-                onSelectionChange={handleClaimsLibrarySelection}
-              >
-                {TEST_CLAIMS.map(library => (
-                  <Item key={library.id}>{library.name}</Item>
-                ))}
-              </Picker>
+              <Flex direction="row" justifyContent="space-between" alignItems="center" marginBottom="size-100">
+              <Heading level={4}>Experiences</Heading>
+                <Button 
+                  variant="secondary"
+                  onPress={getExperience}
+                  UNSAFE_style={{ minWidth: 'auto' }}
+                >
+                  Sync
+                </Button>
+              </Flex>
+              <Divider size="S" />
+              <View marginTop="size-200">
+                <Heading level={4}>Claim Libraries</Heading>
+                <Picker
+                  label="Select a claim library"
+                  width="100%"
+                  onSelectionChange={handleClaimsLibrarySelection}
+                >
+                  {TEST_CLAIMS.map(library => (
+                    <Item key={library.id}>{library.name}</Item>
+                  ))}
+                </Picker>
+              </View>
               <Divider size="S" />
                 <ComboBox 
                   label="Select Experience to Run Claims Check" 
@@ -154,7 +160,13 @@ export default function RightPanel(): JSX.Element {
                   <Spinner />
                 </View>
               ) : claimsResult && (
-                <ClaimsChecker claims={claimsResult} experienceNumber={selectedExperienceIndex || 0} />
+                <View>
+                  <Divider size="S" />
+                  <View paddingX="size-200" paddingTop="size-200">
+                    <Heading level={4}>Claims Results</Heading>
+                  </View>
+                  <ClaimsChecker claims={claimsResult} experienceNumber={selectedExperienceIndex || 0} />
+                </View>
               )}
 
             </Flex>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add sync button, also clean up and add dividers so app isn't so busy

## Related Issue

https://jira.corp.adobe.com/browse/GS-11080

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?


https://github.com/user-attachments/assets/ffcee8a6-4dfd-48bb-a33d-40706dcd9313
https://github.com/user-attachments/assets/8b62e4b7-328f-4aaf-b6a5-b90446f0aa1e

https://github.com/user-attachments/assets/119c4fe7-38aa-4d59-9e6a-54a7b8b1aa0a



## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.