### PR TITLE
GS-11614 fix: Repopulate claims after removing filter

### DIFF
--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
@@ -49,20 +49,19 @@ export default function AdditionalContextDialog(): JSX.Element {
   };
 
   useEffect(() => {
-    const filteredClaims = TEST_CLAIMS.find(library => library.id === selectedClaimLibrary)?.claims.filter(claim =>
-      claim.description.toLowerCase().includes(searchTerm.toLowerCase())
-    ) || [];
-    setClaimsList(filteredClaims);
-    setFilteredClaimsList(filteredClaims);
+    const libraryClaims =
+      TEST_CLAIMS.find((library) => library.id === selectedClaimLibrary)?.claims || [];
+    setClaimsList(libraryClaims);
+    setFilteredClaimsList(libraryClaims);
     setDisableSearch(!selectedClaimLibrary);
   }, [selectedClaimLibrary]);
 
   useEffect(() => {
-    const filteredClaims = claimsList.filter(claim =>
+    const filteredClaims = claimsList.filter((claim) =>
       claim.description.toLowerCase().includes(searchTerm.toLowerCase())
-    ) || [];
+    );
     setFilteredClaimsList(filteredClaims);
-  }, [searchTerm]);
+  }, [searchTerm, claimsList]);
 
   return (
     <Provider theme={defaultTheme}>


### PR DESCRIPTION
## Description

Fix bug in additional context dialog where a filtered list of claims does not repopulate if:

1. a claims library is selected from the picker
1. a search term is entered into the search field (and filters at least one claim)
1. a different claims library is selected
1. the claims library from step 1 is reselected
1. the search term is cleared with the "X" button in the search field

## Related Issue

Claims in dialog do not repopulate after removing search filter.

## Motivation and Context

Fixes bug where users might unknowingly hide claims in a claims library.

## How Has This Been Tested?

Reproducing bug until it was fixed, then trying to break search with this fix implemented.

## Screenshots (if appropriate):

Bug:

![dialog-claims-search-bug](https://github.com/user-attachments/assets/ad564aad-f558-4a4f-9a1a-ede94dd4bbc3)

Fix:

![dialog-claims-search-fix](https://github.com/user-attachments/assets/ab996b31-c1ef-4872-a6d0-ba8bfb9cea0f)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.