### PR TITLE
GS-11645 feat: Remove search field from dialog

### DIFF
--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
@@ -22,7 +22,6 @@ import {
   ButtonGroup,
   Checkbox,
   Flex,
-  SearchField,
   View,
 } from "@adobe/react-spectrum";
 import React, { useEffect, useState } from "react";
@@ -32,11 +31,8 @@ import { useGuestConnection, useSelectedClaimLibrary } from "../hooks";
 import { ClaimsLibraryPicker } from "./ClaimsLibraryPicker";
 
 export default function AdditionalContextDialog(): JSX.Element {
-  const [searchTerm, setSearchTerm] = useState<string>("");
-  const [claimsList, setClaimsList] = useState<Claim[]>([]);
   const [filteredClaimsList, setFilteredClaimsList] = useState<Claim[]>([]);
   const [selectedClaims, setSelectedClaims] = useState<Claim[]>([]);
-  const [disableSearch, setDisableSearch] = useState<boolean>(true);
 
   const guestConnection = useGuestConnection(extensionId);
   const { selectedClaimLibrary, handleClaimsLibrarySelection } =
@@ -44,22 +40,10 @@ export default function AdditionalContextDialog(): JSX.Element {
 
   useEffect(() => {
     const libraryClaims =
-      TEST_CLAIMS.find((library) => library.id === selectedClaimLibrary)?.claims || [];
-    setClaimsList(libraryClaims);
+      TEST_CLAIMS.find((library) => library.id === selectedClaimLibrary)
+        ?.claims || [];
     setFilteredClaimsList(libraryClaims);
-    setDisableSearch(!selectedClaimLibrary);
   }, [selectedClaimLibrary]);
-
-  useEffect(() => {
-    const filteredClaims = claimsList.filter((claim) =>
-      claim.description.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredClaimsList(filteredClaims);
-  }, [searchTerm, claimsList]);
-
-  const handleSearchChange = (value: string) => {
-    setSearchTerm(value);
-  };
 
   const handleClaimChange = (claim: Claim) => {
     setSelectedClaims((prev) =>
@@ -96,13 +80,6 @@ export default function AdditionalContextDialog(): JSX.Element {
         >
           <ClaimsLibraryPicker
             handleSelectionChange={handleClaimsLibrarySelection}
-          />
-          <SearchField
-            label="Search claims"
-            width="60%"
-            value={searchTerm}
-            onChange={handleSearchChange}
-            isDisabled={disableSearch}
           />
           <Flex direction="column" gap="size-100">
             {filteredClaimsList.map((claim) => (


### PR DESCRIPTION
## Description

Remove search field and associated functionality (filter claims by search term) from AdditionalContextDialog.

## Related Issue

Remove search field from add-on dialog.

## Motivation and Context

Search feature was deemed non-essential and is:

- potentially confusing to users,
- poses unaddressed design questions, and
- may introduce bugs (eg. PR #21).

## How Has This Been Tested?

- Ensured claims are still populated based on selected claims library (selected from "Select claim library" picker).
- Ensured list of claims updates when a new claims library is selected.
- Verified that "Search claims" search field no longer appears in dialog.

## Screenshots (if appropriate):

Before (dialog with search field):

<img width="1464" alt="d892373-dialog-with-search-field" src="https://github.com/user-attachments/assets/62c0fef2-96aa-41a5-bc41-a56446103fe3" />

\
After:

![d892373-dialog-without-search-field](https://github.com/user-attachments/assets/3f440863-74ae-46c0-9caa-4ff8cebf6ad1)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.