### PR TITLE
fix: Make claims section scrollable in dialog

### DIFF
--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
@@ -22,6 +22,7 @@ import {
   ButtonGroup,
   Checkbox,
   Flex,
+  Grid,
   View,
 } from "@adobe/react-spectrum";
 import React, { useEffect, useState } from "react";
@@ -70,17 +71,20 @@ export default function AdditionalContextDialog(): JSX.Element {
 
   return (
     <View backgroundColor="static-white" height="100vh">
-      <Flex height="100%" direction="column" justifyContent="space-between">
-        <Flex
-          height="100%"
-          direction="column"
-          marginX="size-200"
-          marginY="size-200"
-          gap="size-300"
-        >
+      <Grid
+        columns={["1fr"]}
+        rows={["auto", "1fr", "auto"]}
+        areas={["library", "claims", "actions"]}
+        height="100%"
+        marginX="size-200"
+        gap="size-300"
+      >
+        <View gridArea="library" marginTop="size-150">
           <ClaimsLibraryPicker
             handleSelectionChange={handleClaimsLibrarySelection}
           />
+        </View>
+        <View gridArea="claims" overflow="auto">
           <Flex direction="column" gap="size-100">
             {filteredClaimsList.map((claim) => (
               <Checkbox
@@ -93,8 +97,8 @@ export default function AdditionalContextDialog(): JSX.Element {
               </Checkbox>
             ))}
           </Flex>
-        </Flex>
-        <ButtonGroup align="end">
+        </View>
+        <ButtonGroup gridArea="actions" align="end">
           <Button variant="secondary" onPress={handleCancel}>
             Cancel
           </Button>
@@ -102,7 +106,7 @@ export default function AdditionalContextDialog(): JSX.Element {
             Select
           </Button>
         </ButtonGroup>
-      </Flex>
+      </Grid>
     </View>
   );
 }


### PR DESCRIPTION
## Description

Enable scrolling in the claims section of AdditionalContextDialog (add-ons dialog).

When more claims were added than the static height of the dialog, the entire dialog (including the "Cancel" and "Select" buttons) became scrollable, hiding the action buttons below the fold. This PR makes only the claims section scrollable, keeping the buttons always visible at the bottom of the dialog.

## Related Issue

Extensibility UI polish.
Stick context add-on dialog buttons to bottom of dialog.

## Motivation and Context

Enhances UX and keeps the "Cancel" and "Select" buttons always visible/accessible in the dialog.

## How Has This Been Tested?

Tested various numbers of claims with this array map:

```tsx
const repeatCount = 6;

{Array.from({ length: repeatCount }).map((_, index) => (
  <Checkbox key={`another-claim-${index + 1}`} marginStart="size-50">
    Another claim.
  </Checkbox>
))}
```

Confirmed that claims section is:

- scrollable when the number of claims exceeds the height of the section (>5 claims) and
- _not_ scrollable when the number of claims _does not_ exceed the height of the section (<6 claims)

and that (1) the dialog buttons are always visible and (2) the entire dialog is no longer scrollable, in both cases.

## Screenshots (if appropriate):

Before - entire dialog is scrollable (hiding dialog buttons):

![4353fcb-entire-dialog-scrollable-bug](https://github.com/user-attachments/assets/22f99925-a498-47d2-a1fa-f82c8d35ec72)

4353fcb - only claims section is scrollable:

![4353fcb-only-claims-scrollable](https://github.com/user-attachments/assets/1647b78b-e73b-4784-b1dd-dac85855b29f)

Short, non-scrollable list of claims:

<img width="500" alt="4353fcb-short-non-scrollable-list-of-claims" src="https://github.com/user-attachments/assets/624fd09f-7744-404c-b5b7-9c5a19598b50" />

\
Appearance when no claims library is selected:

<img width="500" alt="4353fcb-no-claim-library-selected" src="https://github.com/user-attachments/assets/fa8e01e6-f33a-4b15-bbcc-29d838cd391a" />

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.